### PR TITLE
Use latest jesse to support builds on OTP 22, 23

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
     [{lager, {git, "https://github.com/erlang-lager/lager.git", {ref, "69b4ada"}}},
      {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git", {ref, "a043272"}}},
      {yamerl, "0.7.0"},
-     {jesse, {git, "https://github.com/for-GET/jesse.git", {ref, "9f9d050"}}}
+     {jesse, {git, "https://github.com/for-GET/jesse.git", {ref, "bf5ba4b"}}}
     ]
 }.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -27,7 +27,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"jesse">>,
   {git,"https://github.com/for-GET/jesse.git",
-      {ref,"9f9d050627093d6a43e02a102d78122f0c4989c8"}},
+      {ref,"bf5ba4b6445ee8015cfc0e9ea43a5ce66be0f0c2"}},
   0},
  {<<"jsx">>,
   {git,"https://github.com/talentdeficit/jsx.git",
@@ -37,13 +37,11 @@
   {git,"https://github.com/erlang-lager/lager.git",
       {ref,"69b4ada2341b8ab2cf5c8e464ac936e5e4a9f62b"}},
   0},
- {<<"rfc3339">>,
-  {git,"git://github.com/andreineculau/rfc3339.git",
-      {ref,"dcc77d66430490620677de8140a3415dfbd3fa61"}},
-  1},
+ {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.2.2">>},1},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"rfc3339">>, <<"1552DF616ACA368D982E9F085A0E933B6688A3F4938A671798978EC2C0C58730">>},
  {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
 ].


### PR DESCRIPTION
Related to issue aeternity/aeternity#3293, this PR updates to a version of jesse that avoids compiler warnings on OTP 22 and 23.